### PR TITLE
Add 2019 – The Year That Was quiz pack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/community-packs/2019-the-year-that-was.json
+++ b/community-packs/2019-the-year-that-was.json
@@ -1,0 +1,528 @@
+{
+  "name": "2019 – The Year That Was",
+  "version": "1.0",
+  "author": "Obot",
+  "description": "A challenging, in-depth look at the events, pop culture, sports, science, and surprises that defined 2019. All questions are medium or hard—no easy points here!",
+  "rounds": [
+    {
+      "round_number": 1,
+      "theme_name": "Streaming into the Spotlight",
+      "theme_description": "Major TV, film, and streaming moments of 2019.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "Which HBO series concluded in 2019 with a controversial final season that divided fans and critics alike?",
+          "answer": "Game of Thrones",
+          "explanation": "The eighth and final season of 'Game of Thrones' aired in 2019, sparking widespread debate over its ending.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which streaming service released the miniseries ‘When They See Us,’ based on the Central Park Five case, in 2019?",
+          "options": ["Hulu", "Netflix", "Amazon Prime", "Apple TV+"],
+          "answer": "Netflix",
+          "explanation": "Ava DuVernay’s ‘When They See Us’ premiered on Netflix in May 2019.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "The Mandalorian was the first original series released on Disney+ in 2019.",
+          "answer": "true",
+          "explanation": "'The Mandalorian' was the flagship original series at Disney+'s launch in November 2019.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many Emmy Awards did ‘Fleabag’ win at the 2019 Primetime Emmy Awards?",
+          "answer": "6",
+          "explanation": "'Fleabag' won six Emmys, including Outstanding Comedy Series and Lead Actress for Phoebe Waller-Bridge.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Who played the title character in the 2019 Netflix series ‘The Witcher’?",
+          "answer": "Henry Cavill",
+          "explanation": "Henry Cavill starred as Geralt of Rivia in the fantasy series 'The Witcher.'",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "What 2019 film is shown in this image?",
+          "image_path": "/images/us-red-jumpsuit.jpg",
+          "answer": "Us",
+          "explanation": "Jordan Peele’s horror film 'Us' was released in 2019 and became a cultural phenomenon.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 2,
+      "theme_name": "On the World Stage",
+      "theme_description": "International news events and global happenings.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "Which European city’s iconic cathedral suffered a devastating fire in April 2019?",
+          "answer": "Paris",
+          "explanation": "The Notre Dame Cathedral in Paris was severely damaged by fire in April 2019.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Who became the Prime Minister of the United Kingdom in July 2019?",
+          "options": ["Theresa May", "Boris Johnson", "Jeremy Corbyn", "David Cameron"],
+          "answer": "Boris Johnson",
+          "explanation": "Boris Johnson succeeded Theresa May as UK Prime Minister in July 2019.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "In 2019, the Amazon rainforest experienced its lowest number of fires in a decade.",
+          "answer": "false",
+          "explanation": "2019 saw a dramatic increase in Amazon rainforest fires, drawing global concern.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many days did the 2019 Hong Kong protests last, from June to December?",
+          "answer": "200",
+          "explanation": "The protests spanned roughly 200 days, making them one of the longest-running in Hong Kong’s history.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which country officially left the Intermediate-Range Nuclear Forces Treaty with the United States in August 2019?",
+          "answer": "Russia",
+          "explanation": "Both the U.S. and Russia withdrew from the INF Treaty in 2019.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "What protest movement is shown in this image from 2019?",
+          "image_path": "/images/yellow-vests-france.jpg",
+          "answer": "Yellow Vests (Gilets Jaunes)",
+          "explanation": "The Yellow Vests movement in France continued to make headlines in 2019.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 3,
+      "theme_name": "Chart Toppers & Earworms",
+      "theme_description": "Music hits, artists, and trends that defined 2019.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "Which song by Lil Nas X broke the record for longest-running number one on the Billboard Hot 100 in 2019?",
+          "answer": "Old Town Road",
+          "explanation": "'Old Town Road' spent 19 weeks at number one, a new record.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Who won the Grammy for Album of the Year in 2019 (awarded in early 2020)?",
+          "options": ["Billie Eilish", "Ariana Grande", "Lizzo", "Taylor Swift"],
+          "answer": "Billie Eilish",
+          "explanation": "Billie Eilish’s 'When We All Fall Asleep, Where Do We Go?' won Album of the Year.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "BTS became the first K-pop group to perform on Saturday Night Live in 2019.",
+          "answer": "true",
+          "explanation": "BTS made their SNL debut in April 2019.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many Grammy Awards did Billie Eilish win at the 2020 ceremony for her 2019 work?",
+          "answer": "5",
+          "explanation": "Billie Eilish won five major Grammys, including Album, Record, and Song of the Year.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which Spanish-language song by Rosalía won Best New Latin Artist at the 2019 MTV VMAs?",
+          "answer": "Con Altura",
+          "explanation": "'Con Altura' by Rosalía and J Balvin was a major hit and won at the VMAs.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "Who is this artist holding multiple Grammy trophies in 2019?",
+          "image_path": "/images/billie-eilish-grammys.jpg",
+          "answer": "Billie Eilish",
+          "explanation": "Billie Eilish dominated the 2020 Grammys for her 2019 album.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 4,
+      "theme_name": "Game Changers",
+      "theme_description": "Sports milestones, tournaments, and athletes.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "Which country won the 2019 Cricket World Cup in a dramatic final decided by a Super Over?",
+          "answer": "England",
+          "explanation": "England won their first Cricket World Cup after a tie-breaking Super Over against New Zealand.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Who was named NBA Finals MVP after leading the Toronto Raptors to their first championship in 2019?",
+          "options": ["Kyle Lowry", "Kawhi Leonard", "Pascal Siakam", "Marc Gasol"],
+          "answer": "Kawhi Leonard",
+          "explanation": "Kawhi Leonard was instrumental in the Raptors’ victory.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "The U.S. Women’s National Soccer Team won their third FIFA Women’s World Cup in 2019.",
+          "answer": "false",
+          "explanation": "2019 marked their fourth World Cup win, not third.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many major golf championships had Tiger Woods won after his 2019 Masters victory?",
+          "answer": "15",
+          "explanation": "Tiger Woods’ 2019 Masters win was his 15th major title.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which tennis player won both the Australian Open and Wimbledon men’s singles titles in 2019?",
+          "answer": "Novak Djokovic",
+          "explanation": "Djokovic won both tournaments in 2019.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "Who is this basketball player holding the NBA Finals MVP trophy in 2019?",
+          "image_path": "/images/kawhi-leonard-mvp.jpg",
+          "answer": "Kawhi Leonard",
+          "explanation": "Leonard was the 2019 NBA Finals MVP for the Toronto Raptors.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 5,
+      "theme_name": "Tech & Tomorrow",
+      "theme_description": "Scientific breakthroughs, tech launches, and discoveries.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What astronomical object was imaged for the first time ever in April 2019, making global headlines?",
+          "answer": "Black hole",
+          "explanation": "The Event Horizon Telescope captured the first image of a black hole in the galaxy M87.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which company became the world’s most valuable publicly traded company in 2019, briefly surpassing $1 trillion in market value?",
+          "options": ["Microsoft", "Apple", "Amazon", "Saudi Aramco"],
+          "answer": "Saudi Aramco",
+          "explanation": "Saudi Aramco’s IPO made it the world’s most valuable company in December 2019.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "In 2019, Google announced the achievement of ‘quantum supremacy.’",
+          "answer": "true",
+          "explanation": "Google claimed its quantum computer performed a calculation faster than any classical computer.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many satellites did SpaceX launch in its first Starlink mission in May 2019?",
+          "answer": "60",
+          "explanation": "The first Starlink launch deployed 60 satellites.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which foldable smartphone, released in 2019, was delayed due to screen durability issues?",
+          "answer": "Samsung Galaxy Fold",
+          "explanation": "The Galaxy Fold’s launch was postponed after early review units broke.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "What is this famous astronomical image from 2019?",
+          "image_path": "/images/black-hole-m87.jpg",
+          "answer": "First image of a black hole",
+          "explanation": "This is the first-ever image of a black hole, released in April 2019.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 6,
+      "theme_name": "Viral Moments",
+      "theme_description": "Memes, social media trends, and internet phenomena.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What simple photo became the most-liked Instagram post ever in January 2019, surpassing Kylie Jenner’s record?",
+          "answer": "An egg",
+          "explanation": "The ‘World Record Egg’ became a viral sensation, amassing over 50 million likes.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which viral challenge involved people dancing to Drake’s ‘In My Feelings’ outside moving cars, but was officially discouraged in 2019 due to safety concerns?",
+          "options": ["Ice Bucket Challenge", "Mannequin Challenge", "Kiki Challenge", "Harlem Shake"],
+          "answer": "Kiki Challenge",
+          "explanation": "The Kiki Challenge went viral but was criticized for its dangers.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "The ‘Storm Area 51’ Facebook event in 2019 resulted in thousands of people actually storming the military base.",
+          "answer": "false",
+          "explanation": "While millions RSVP’d, only a few showed up, and no one stormed the base.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many people marked themselves as ‘going’ to the ‘Storm Area 51’ event on Facebook?",
+          "answer": "2 million",
+          "explanation": "Over 2 million people RSVP’d to the viral event.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which app, popularized in 2019, uses AI to age or de-age users’ faces in photos?",
+          "answer": "FaceApp",
+          "explanation": "FaceApp’s aging filter went viral in 2019.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "What viral 2019 phenomenon is this image of a brown egg associated with?",
+          "image_path": "/images/world-record-egg.jpg",
+          "answer": "World Record Egg",
+          "explanation": "The egg became the most-liked Instagram post ever in 2019.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 7,
+      "theme_name": "Blockbusters & Box Office",
+      "theme_description": "Major movies, cinematic records, and film industry news.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "Which film became the highest-grossing movie of all time in 2019, surpassing ‘Avatar’?",
+          "answer": "Avengers: Endgame",
+          "explanation": "'Avengers: Endgame' grossed over $2.7 billion worldwide.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Who won the Academy Award for Best Director at the 2019 Oscars (for films released in 2018)?",
+          "options": ["Alfonso Cuarón", "Spike Lee", "Yorgos Lanthimos", "Adam McKay"],
+          "answer": "Alfonso Cuarón",
+          "explanation": "Cuarón won for 'Roma' at the 2019 Oscars.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "The 2019 film ‘Parasite’ was the first South Korean movie to win the Palme d’Or at Cannes.",
+          "answer": "true",
+          "explanation": "'Parasite' made history at Cannes in 2019.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many Oscars did ‘Parasite’ win at the 2020 Academy Awards for its 2019 release?",
+          "answer": "4",
+          "explanation": "'Parasite' won Best Picture, Director, Original Screenplay, and International Feature.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which animated film won the Academy Award for Best Animated Feature in 2019?",
+          "answer": "Spider-Man: Into the Spider-Verse",
+          "explanation": "The film won at the 2019 Oscars for 2018 releases.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "What film is shown in this image of superheroes and a purple-skinned villain?",
+          "image_path": "/images/avengers-endgame.jpg",
+          "answer": "Avengers: Endgame",
+          "explanation": "The film was the biggest box office hit of 2019.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 8,
+      "theme_name": "Leaders & Legends",
+      "theme_description": "Influential figures, awards, and notable passings.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "Who was awarded the 2019 Nobel Peace Prize for efforts to resolve the border conflict with Eritrea?",
+          "answer": "Abiy Ahmed",
+          "explanation": "Ethiopian Prime Minister Abiy Ahmed won the Nobel Peace Prize in 2019.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which fashion designer, known for his work at Chanel, passed away in February 2019?",
+          "options": ["Karl Lagerfeld", "Giorgio Armani", "Jean-Paul Gaultier", "Tom Ford"],
+          "answer": "Karl Lagerfeld",
+          "explanation": "Lagerfeld was a legendary figure in the fashion world.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "In 2019, Angela Merkel announced her resignation as Chancellor of Germany, effective immediately.",
+          "answer": "false",
+          "explanation": "Merkel announced she would not seek re-election, but did not resign in 2019.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many years had Emperor Akihito reigned before abdicating the Japanese throne in 2019?",
+          "answer": "30",
+          "explanation": "Akihito reigned from 1989 to 2019.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Who became the first woman to win the Ballon d’Or Féminin (Women’s Ballon d’Or) in 2019?",
+          "answer": "Megan Rapinoe",
+          "explanation": "Rapinoe was honored for her achievements in women’s soccer.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "Who is this man holding a Nobel medal with an Ethiopian flag in the background?",
+          "image_path": "/images/abiy-ahmed-nobel.jpg",
+          "answer": "Abiy Ahmed",
+          "explanation": "Ahmed received the Nobel Peace Prize in 2019.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 9,
+      "theme_name": "Changing the Game",
+      "theme_description": "Social movements, activism, and cultural shifts.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "Which Swedish activist delivered a powerful speech at the UN Climate Action Summit in 2019, sparking global youth protests?",
+          "answer": "Greta Thunberg",
+          "explanation": "Thunberg’s ‘How dare you?’ speech became a rallying cry for climate action.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which U.S. state became the first to ban the sale of new fur products in 2019?",
+          "options": ["New York", "California", "Oregon", "Washington"],
+          "answer": "California",
+          "explanation": "California passed the landmark law in October 2019.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "The ‘OK Boomer’ meme became a popular retort to dismiss out-of-touch attitudes in 2019.",
+          "answer": "true",
+          "explanation": "The phrase went viral as a generational catchphrase.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many countries participated in the Global Climate Strike in September 2019?",
+          "answer": "150",
+          "explanation": "Over 150 countries joined the climate protests.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which U.S. city hosted the first-ever WorldPride event in the United States in 2019?",
+          "answer": "New York City",
+          "explanation": "NYC hosted WorldPride to mark the 50th anniversary of Stonewall.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "Who is this young woman holding a ‘Skolstrejk för klimatet’ sign?",
+          "image_path": "/images/greta-thunberg-strike.jpg",
+          "answer": "Greta Thunberg",
+          "explanation": "Thunberg became the face of youth climate activism in 2019.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 10,
+      "theme_name": "The Year in Review",
+      "theme_description": "Miscellaneous events, quirky facts, and surprising headlines from 2019.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "Which Japanese city hosted the G20 summit in June 2019?",
+          "answer": "Osaka",
+          "explanation": "The G20 leaders met in Osaka, Japan, in June 2019.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which company’s CEO stepped down in 2019 after a scandal involving data privacy and security breaches?",
+          "options": ["Facebook", "Google", "Twitter", "Equifax"],
+          "answer": "Google",
+          "explanation": "Google co-founders Larry Page and Sergey Brin stepped down from their roles at Alphabet in 2019.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "In 2019, the kilogram was redefined based on a physical object kept in France.",
+          "answer": "false",
+          "explanation": "The kilogram was redefined using fundamental constants, ending reliance on a physical object.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many years had it been since the last total solar eclipse visible from South America before the one in July 2019?",
+          "answer": "25",
+          "explanation": "The previous total solar eclipse visible from South America was in 1994.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which video game won Game of the Year at The Game Awards 2019?",
+          "answer": "Sekiro: Shadows Die Twice",
+          "explanation": "'Sekiro: Shadows Die Twice' was awarded Game of the Year.",
+          "points": 1
+        },
+        {
+          "type": "image",
+          "question": "What is the name of this 2019 video game featuring a samurai warrior?",
+          "image_path": "/images/sekiro-samurai.jpg",
+          "answer": "Sekiro: Shadows Die Twice",
+          "explanation": "The game won top honors at The Game Awards 2019.",
+          "points": 1
+        }
+      ]
+    }
+  ]
+}

--- a/community-packs/README.md
+++ b/community-packs/README.md
@@ -39,12 +39,25 @@ Holiday-themed and seasonal quiz packs for special occasions.
 ## ✨ Featured Packs
 
 ### Recently Added
-- **🌉 Northern California Chronicles** by Shannon Williams - Bay Area and Northern California
-- **⛷️ Skiing Around The World** by Shannon Williams - Global skiing destinations and culture
+- **🌉 [Northern California Chronicles](geography/northern-california-chronicles.json)** by Shannon Williams  
+  *10 rounds exploring Bay Area culture, landmarks, and history*  
+  📊 Difficulty: Mixed | 🎯 Audience: Adults | ⏱️ ~60 minutes
+
+- **⛷️ [Skiing Around The World](sports/skiing_around_the_world_v1.0.json)** by Shannon Williams  
+  *Global skiing destinations, culture, and winter sports*  
+  📊 Difficulty: Medium | 🎯 Audience: General | ⏱️ ~60 minutes
 
 ### Most Popular
 - **🐻 Bear Essentials** (Built-in) - Bear-themed questions across various topics
 - **🤔 Quizzlies Quirky Questions Vol 1** (Built-in) - Creative and unusual trivia
+
+### 🔍 **Quick Pack Finder**
+
+**Looking for something specific?**
+- 🏠 **Local Interest**: [Northern California Chronicles](geography/northern-california-chronicles.json)
+- ⚽ **Sports Fans**: [Skiing Around The World](sports/skiing_around_the_world_v1.0.json)
+- 🌍 **Geography Buffs**: Browse the [geography/](geography/) folder
+- 🏃 **Quick Games**: Packs marked "30 minutes" for shorter sessions
 
 ## 🤝 Contributing Your Own Pack
 

--- a/community-packs/geography/README.md
+++ b/community-packs/geography/README.md
@@ -1,0 +1,58 @@
+# 🗺️ Geography Quiz Packs
+
+Explore the world from your quiz table! Geography packs covering countries, capitals, landmarks, cultures, and places around the globe.
+
+## 📦 Available Packs
+
+### 🌉 Northern California Chronicles
+**File**: [northern-california-chronicles.json](northern-california-chronicles.json)  
+**Author**: Shannon Williams  
+**Version**: 1.0  
+**Rounds**: 10 | **Questions**: 60 | **Duration**: ~60 minutes
+
+**Description**: Dive deep into Bay Area culture, landmarks, and Northern California history. Perfect for locals and California enthusiasts!
+
+**What's Included**:
+- San Francisco landmarks and neighborhoods
+- Bay Area tech culture and history
+- Northern California wine regions
+- Local food culture and traditions
+- Regional geography and natural features
+- Historical events and figures
+- Transportation and infrastructure
+- Cultural institutions and attractions
+
+**Difficulty**: Mixed (Easy to Hard)  
+**Best For**: Adults familiar with California or interested in regional trivia  
+**Sample Question**: "What unusual color was chosen for the Bay Area's most famous suspension bridge?"
+
+[📥 Download Pack](northern-california-chronicles.json) | [🔍 Preview Questions](#)
+
+---
+
+## 🎯 Pack Suggestions Needed
+
+Missing something? We'd love packs about:
+- **World Capitals** - Test knowledge of global capitals
+- **European Countries** - Dive into European geography and culture  
+- **Famous Landmarks** - Iconic buildings and natural wonders
+- **Islands of the World** - Island nations and territories
+- **Mountain Ranges** - Peaks, ranges, and geological features
+- **Rivers and Lakes** - Major waterways around the globe
+- **U.S. States** - American geography and state facts
+- **African Geography** - Countries, cultures, and geography of Africa
+
+## 🤝 Contributing
+
+Have a geography pack to share? See our [contribution guide](../README.md#contributing-your-own-pack) to get started!
+
+**Geography Pack Tips**:
+- Balance famous locations with lesser-known gems
+- Include cultural context, not just geographic facts
+- Mix physical geography with human geography
+- Consider regional specialties that locals would enjoy
+- Verify all place names, spellings, and facts carefully
+
+---
+
+**🔙 [Back to Community Packs](../README.md)**

--- a/community-packs/harry-potter/harry-potter-the-early-years.json
+++ b/community-packs/harry-potter/harry-potter-the-early-years.json
@@ -1,0 +1,138 @@
+{
+  "name": "Harry Potter: The Early Years Quiz Pack",
+  "version": "1.0",
+  "author": "Obot (Acorn Labs)",
+  "description": "A magical quiz pack covering the first three Harry Potter books. Test your knowledge of Hogwarts, its students, and the wizarding world up through Prisoner of Azkaban.",
+  "rounds": [
+    {
+      "round_number": 1,
+      "theme_name": "First Impressions",
+      "theme_description": "Moments and details from the beginnings of Harry's magical journey.",
+      "questions": [
+        {"type": "text_answer", "question": "What is the name of the train that takes students to Hogwarts?", "answer": "Hogwarts Express", "explanation": "The Hogwarts Express departs from King's Cross Station, Platform 9¾, and brings students to Hogwarts each year.", "points": 1},
+        {"type": "multiple_choice", "question": "Which house does Draco Malfoy get sorted into?", "options": ["Gryffindor", "Slytherin", "Ravenclaw", "Hufflepuff"], "answer": "Slytherin", "explanation": "Draco Malfoy is sorted into Slytherin, known for ambition and cunning.", "points": 1},
+        {"type": "true_false", "question": "Harry's first friend at Hogwarts is Ron Weasley.", "answer": "true", "explanation": "Harry meets Ron on the train and they quickly become friends.", "points": 1},
+        {"type": "closest_number", "question": "How old is Harry when he receives his Hogwarts letter? (in years)", "answer": "11", "explanation": "Harry turns 11 just before receiving his letter, the standard age for first-year students.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "What is the last name of the family Harry lives with before Hogwarts?", "answer": "Dursley", "explanation": "Harry lives with his aunt, uncle, and cousin—the Dursleys—at 4 Privet Drive.", "points": 1},
+        {"type": "multiple_choice", "question": "Who delivers Harry's Hogwarts letter in person?", "options": ["Professor McGonagall", "Hagrid", "Dumbledore", "Sirius Black"], "answer": "Hagrid", "explanation": "Hagrid personally delivers Harry's letter after the Dursleys try to keep it from him.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 2,
+      "theme_name": "Unusual Pets",
+      "theme_description": "Magical creatures and companions at Hogwarts.",
+      "questions": [
+        {"type": "text_answer", "question": "What is the name of Hermione's cat, introduced in book 3?", "answer": "Crookshanks", "explanation": "Crookshanks is Hermione's squashed-faced, clever cat, introduced in Prisoner of Azkaban.", "points": 1},
+        {"type": "multiple_choice", "question": "What type of animal is Scabbers?", "options": ["Owl", "Rat", "Toad", "Cat"], "answer": "Rat", "explanation": "Scabbers is Ron's pet rat, who turns out to be more than he seems.", "points": 1},
+        {"type": "true_false", "question": "Hedwig is a snowy owl.", "answer": "true", "explanation": "Harry's loyal pet, Hedwig, is a snowy owl given to him by Hagrid.", "points": 1},
+        {"type": "closest_number", "question": "How many heads does Fluffy, the dog guarding the trapdoor, have?", "answer": "3", "explanation": "Fluffy is a giant three-headed dog owned by Hagrid.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "What is the name of Hagrid's pet dragon in book 1?", "answer": "Norbert", "explanation": "Norbert is a Norwegian Ridgeback dragon hatched by Hagrid in Sorcerer's Stone.", "points": 1},
+        {"type": "multiple_choice", "question": "What kind of creature is Trevor?", "options": ["Toad", "Cat", "Owl", "Rat"], "answer": "Toad", "explanation": "Trevor is Neville Longbottom's pet toad.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 3,
+      "theme_name": "Magical Mishaps",
+      "theme_description": "Spells gone wrong and magical accidents.",
+      "questions": [
+        {"type": "text_answer", "question": "What spell does Ron try to use to turn Scabbers yellow?", "answer": "Sunshine, daisies, butter mellow", "explanation": "Ron attempts a rhyme, not a real spell, to turn Scabbers yellow on the train.", "points": 1},
+        {"type": "multiple_choice", "question": "What happens when Harry tries to use Floo Powder for the first time?", "options": ["He arrives at Hogwarts", "He ends up in Knockturn Alley", "He loses his glasses", "He meets Dobby"], "answer": "He ends up in Knockturn Alley", "explanation": "Harry mispronounces 'Diagon Alley' and ends up in the dark Knockturn Alley.", "points": 1},
+        {"type": "true_false", "question": "Hermione accidentally turns herself into a cat in book 2.", "answer": "true", "explanation": "Hermione uses a hair from Millicent Bulstrode's cat in Polyjuice Potion, turning herself part-cat.", "points": 1},
+        {"type": "closest_number", "question": "How many points does Gryffindor lose when Harry, Hermione, and Neville are caught out of bed in book 1?", "answer": "150", "explanation": "They lose 50 points each, totaling 150 points for Gryffindor.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "Who gets turned into a ferret by Professor Moody (Barty Crouch Jr.)? (Trick: Only up to book 3)", "answer": "No one", "explanation": "This event happens in book 4, not in the first three books.", "points": 1},
+        {"type": "multiple_choice", "question": "What does Neville receive from Professor McGonagall after forgetting the password?", "options": ["A detention", "A Howler", "A Remembrall", "A Chocolate Frog"], "answer": "A Howler", "explanation": "Neville receives a Howler from his grandmother for forgetting the password to Gryffindor Tower.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 4,
+      "theme_name": "School Rules & Rebels",
+      "theme_description": "Breaking and following the rules at Hogwarts.",
+      "questions": [
+        {"type": "text_answer", "question": "What is the name of the caretaker who patrols Hogwarts with his cat?", "answer": "Argus Filch", "explanation": "Argus Filch is the cantankerous caretaker, often accompanied by his cat, Mrs. Norris.", "points": 1},
+        {"type": "multiple_choice", "question": "Which corridor is forbidden in Harry's first year?", "options": ["Third floor", "Fourth floor", "Dungeon", "Seventh floor"], "answer": "Third floor", "explanation": "The third-floor corridor is forbidden because it hides the trapdoor to the Sorcerer's Stone.", "points": 1},
+        {"type": "true_false", "question": "Fred and George Weasley give Harry the Marauder's Map in book 3.", "answer": "true", "explanation": "The twins give Harry the Marauder's Map so he can sneak into Hogsmeade.", "points": 1},
+        {"type": "closest_number", "question": "How many house points does Dumbledore award Neville at the end of book 1?", "answer": "10", "explanation": "Neville receives 10 points for standing up to his friends, helping Gryffindor win the House Cup.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "What magical object allows Harry to become invisible?", "answer": "Invisibility Cloak", "explanation": "Harry receives the Invisibility Cloak as a Christmas present in his first year.", "points": 1},
+        {"type": "multiple_choice", "question": "Who is the strict head of Gryffindor House?", "options": ["Professor Flitwick", "Professor McGonagall", "Professor Snape", "Professor Sprout"], "answer": "Professor McGonagall", "explanation": "Professor McGonagall is the head of Gryffindor House and Transfiguration teacher.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 5,
+      "theme_name": "Quidditch & Competition",
+      "theme_description": "Sports, games, and rivalries at Hogwarts.",
+      "questions": [
+        {"type": "text_answer", "question": "What position does Harry play on the Gryffindor Quidditch team?", "answer": "Seeker", "explanation": "Harry is the youngest Seeker in a century, responsible for catching the Golden Snitch.", "points": 1},
+        {"type": "multiple_choice", "question": "Which ball is used to score points in Quidditch?", "options": ["Bludger", "Snitch", "Quaffle", "Gobstone"], "answer": "Quaffle", "explanation": "The Quaffle is used to score goals, worth 10 points each.", "points": 1},
+        {"type": "true_false", "question": "Slytherin wins the Quidditch Cup in Harry's first year.", "answer": "false", "explanation": "Gryffindor wins the House Cup, but the Quidditch Cup is not awarded in book 1.", "points": 1},
+        {"type": "closest_number", "question": "How many players are on a Quidditch team?", "answer": "7", "explanation": "Each Quidditch team has 7 players: 3 Chasers, 2 Beaters, 1 Keeper, and 1 Seeker.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "Who is the captain of the Gryffindor Quidditch team in book 1?", "answer": "Oliver Wood", "explanation": "Oliver Wood is the dedicated captain and Keeper for Gryffindor.", "points": 1},
+        {"type": "multiple_choice", "question": "Which team is Gryffindor's main rival in Quidditch?", "options": ["Hufflepuff", "Slytherin", "Ravenclaw", "Durmstrang"], "answer": "Slytherin", "explanation": "Gryffindor and Slytherin have a fierce rivalry, especially in Quidditch.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 6,
+      "theme_name": "Hidden Chambers & Secrets",
+      "theme_description": "Mysterious places and secret passages at Hogwarts.",
+      "questions": [
+        {"type": "text_answer", "question": "What is the name of the chamber beneath the trapdoor where the Philosopher's Stone is hidden?", "answer": "The chamber beneath the trapdoor", "explanation": "The Stone is hidden in a chamber beneath the trapdoor, protected by magical obstacles set by Hogwarts staff.", "points": 1},
+        {"type": "multiple_choice", "question": "What creature is hidden in the Chamber of Secrets?", "options": ["Basilisk", "Acromantula", "Dragon", "Phoenix"], "answer": "Basilisk", "explanation": "The Chamber of Secrets houses a deadly Basilisk controlled by the Heir of Slytherin.", "points": 1},
+        {"type": "true_false", "question": "The Marauder's Map shows every person at Hogwarts.", "answer": "true", "explanation": "The Marauder's Map reveals the location of everyone in the castle, including secret passages.", "points": 1},
+        {"type": "closest_number", "question": "How many secret passages out of Hogwarts are shown on the Marauder's Map?", "answer": "7", "explanation": "The Marauder's Map shows seven secret passages leading out of Hogwarts.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "What is the password to Dumbledore's office in book 2?", "answer": "Sherbet Lemon", "explanation": "Dumbledore's office password in Chamber of Secrets is 'Sherbet Lemon,' a Muggle sweet.", "points": 1},
+        {"type": "multiple_choice", "question": "Who opens the Chamber of Secrets in book 2?", "options": ["Harry Potter", "Tom Riddle", "Ginny Weasley", "Draco Malfoy"], "answer": "Ginny Weasley", "explanation": "Ginny Weasley, under the influence of Tom Riddle's diary, opens the Chamber of Secrets.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 7,
+      "theme_name": "Teachers & Lessons",
+      "theme_description": "Professors, classes, and magical education at Hogwarts.",
+      "questions": [
+        {"type": "text_answer", "question": "Who teaches Potions at Hogwarts?", "answer": "Severus Snape", "explanation": "Professor Snape is the Potions Master and head of Slytherin House.", "points": 1},
+        {"type": "multiple_choice", "question": "Which subject does Professor Sprout teach?", "options": ["Herbology", "Charms", "Transfiguration", "Defense Against the Dark Arts"], "answer": "Herbology", "explanation": "Professor Sprout is the Herbology teacher and head of Hufflepuff House.", "points": 1},
+        {"type": "true_false", "question": "Professor Lupin teaches Defense Against the Dark Arts in book 3.", "answer": "true", "explanation": "Remus Lupin is the popular Defense Against the Dark Arts teacher in Prisoner of Azkaban.", "points": 1},
+        {"type": "closest_number", "question": "How many different Defense Against the Dark Arts teachers has Harry had by the end of book 3?", "answer": "3", "explanation": "Harry has had three: Quirrell, Lockhart, and Lupin.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "Who teaches Transfiguration?", "answer": "Minerva McGonagall", "explanation": "Professor McGonagall is the strict but fair Transfiguration teacher.", "points": 1},
+        {"type": "multiple_choice", "question": "Which teacher is revealed to be a werewolf?", "options": ["Professor Snape", "Professor Lupin", "Professor Quirrell", "Professor Flitwick"], "answer": "Professor Lupin", "explanation": "Remus Lupin's secret is revealed in Prisoner of Azkaban.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 8,
+      "theme_name": "Family & Friendship",
+      "theme_description": "Bonds, backgrounds, and relationships in the wizarding world.",
+      "questions": [
+        {"type": "text_answer", "question": "What is Ron's youngest sister's name?", "answer": "Ginny", "explanation": "Ginny Weasley is Ron's only sister and the youngest Weasley sibling.", "points": 1},
+        {"type": "multiple_choice", "question": "Who is Harry's godfather, introduced in book 3?", "options": ["Remus Lupin", "Sirius Black", "Arthur Weasley", "Cornelius Fudge"], "answer": "Sirius Black", "explanation": "Sirius Black is revealed to be Harry's godfather in Prisoner of Azkaban.", "points": 1},
+        {"type": "true_false", "question": "Hermione is Muggle-born.", "answer": "true", "explanation": "Hermione's parents are both non-magical dentists.", "points": 1},
+        {"type": "closest_number", "question": "How many Weasley siblings are there (including Ron)?", "answer": "7", "explanation": "There are seven Weasley children: Bill, Charlie, Percy, Fred, George, Ron, and Ginny.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "What is Hermione's parents' profession?", "answer": "Dentists", "explanation": "Hermione's parents are both dentists, a fact she mentions several times.", "points": 1},
+        {"type": "multiple_choice", "question": "Who is Percy Weasley's girlfriend in book 3?", "options": ["Penelope Clearwater", "Cho Chang", "Lavender Brown", "Angelina Johnson"], "answer": "Penelope Clearwater", "explanation": "Penelope Clearwater is a Ravenclaw prefect and Percy's girlfriend.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 9,
+      "theme_name": "Dark Arts & Dangers",
+      "theme_description": "Villains, curses, and magical threats from the first three books.",
+      "questions": [
+        {"type": "text_answer", "question": "What is the name of the dark wizard who killed Harry's parents?", "answer": "Voldemort", "explanation": "Lord Voldemort, also known as He-Who-Must-Not-Be-Named, is the main antagonist.", "points": 1},
+        {"type": "multiple_choice", "question": "What creature petrifies students in book 2?", "options": ["Basilisk", "Dementor", "Werewolf", "Acromantula"], "answer": "Basilisk", "explanation": "The Basilisk's gaze causes petrification in Chamber of Secrets.", "points": 1},
+        {"type": "true_false", "question": "Dementors guard the entrance to the Chamber of Secrets.", "answer": "false", "explanation": "Dementors guard Azkaban and later Hogwarts, not the Chamber of Secrets.", "points": 1},
+        {"type": "closest_number", "question": "How many times does Harry face Voldemort directly in the first three books?", "answer": "3", "explanation": "Harry faces Voldemort in each of the first three books: the Stone, the diary, and the Shrieking Shack.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "What is the incantation for the spell that repels Dementors?", "answer": "Expecto Patronum", "explanation": "'Expecto Patronum' conjures a Patronus to ward off Dementors, taught to Harry by Lupin.", "points": 1},
+        {"type": "multiple_choice", "question": "Who is revealed to be the true owner of Scabbers?", "options": ["Ron Weasley", "Percy Weasley", "Peter Pettigrew", "Sirius Black"], "answer": "Peter Pettigrew", "explanation": "Scabbers is actually Peter Pettigrew, an Animagus hiding from the wizarding world.", "points": 1}
+      ]
+    },
+    {
+      "round_number": 10,
+      "theme_name": "Wit Beyond Measure",
+      "theme_description": "Riddles, cleverness, and magical trivia from the first three books.",
+      "questions": [
+        {"type": "text_answer", "question": "What is the name of the ghost who haunts the girls' bathroom?", "answer": "Moaning Myrtle", "explanation": "Moaning Myrtle haunts a bathroom at Hogwarts and plays a key role in Chamber of Secrets.", "points": 1},
+        {"type": "multiple_choice", "question": "Which of these plants helps Harry breathe underwater in the first three books?", "options": ["Gillyweed", "Mandrake", "Devil's Snare", "Bubotuber"], "answer": "None", "explanation": "Gillyweed is introduced in book 4, not in the first three books.", "points": 1},
+        {"type": "true_false", "question": "The Sorting Hat once belonged to Godric Gryffindor.", "answer": "true", "explanation": "The Sorting Hat originally belonged to Godric Gryffindor and was enchanted to sort students.", "points": 1},
+        {"type": "closest_number", "question": "How many staircases are there at Hogwarts?", "answer": "142", "explanation": "Hogwarts is famous for its 142 shifting staircases.", "scoring_type": "closest", "points": 1},
+        {"type": "text_answer", "question": "What is the name of the wizarding village near Hogwarts?", "answer": "Hogsmeade", "explanation": "Hogsmeade is the only all-wizarding village in Britain, visited by students from third year on.", "points": 1},
+        {"type": "multiple_choice", "question": "Which of these is NOT a password to Gryffindor Tower in the first three books?", "options": ["Caput Draconis", "Fortuna Major", "Sherbet Lemon", "Pig Snout"], "answer": "Sherbet Lemon", "explanation": "'Sherbet Lemon' is Dumbledore's office password, not for Gryffindor Tower.", "points": 1}
+      ]
+    }
+  ]
+}

--- a/community-packs/pop-culture-ultimate-mixed-trivia-pack.json
+++ b/community-packs/pop-culture-ultimate-mixed-trivia-pack.json
@@ -1,0 +1,528 @@
+{
+  "name": "Pop Culture & Fun: The Ultimate Mixed Trivia Pack",
+  "version": "1.0",
+  "author": "Obot",
+  "description": "A lively quiz pack spanning music, gaming, internet culture, and general knowledge. Each round explores a different fan-favorite topic, from Green Day to Minecraft to memes and more!",
+  "rounds": [
+    {
+      "round_number": 1,
+      "theme_name": "Punk Rock Pulse",
+      "theme_description": "Questions inspired by the music and legacy of Green Day.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is the name of Green Day's breakthrough 1994 album that includes the hits 'Basket Case' and 'When I Come Around'?",
+          "answer": "Dookie",
+          "explanation": "Green Day's 'Dookie' was a massive success and brought punk rock into the mainstream in the 1990s.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which Green Day song begins with the lyrics, 'Do you have the time to listen to me whine'?",
+          "options": ["Basket Case", "Good Riddance", "American Idiot", "Holiday"],
+          "answer": "Basket Case",
+          "explanation": "'Basket Case' is one of Green Day's most iconic songs, opening with those memorable lyrics.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "Green Day's lead singer is Billie Joe Armstrong.",
+          "answer": "true",
+          "explanation": "Billie Joe Armstrong is the frontman and primary songwriter for Green Day.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "In what year was Green Day inducted into the Rock and Roll Hall of Fame?",
+          "answer": "2015",
+          "explanation": "Green Day was inducted in 2015, recognizing their influence on modern rock.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "Which Green Day album features the song 'American Idiot'?",
+          "answer": "American Idiot",
+          "explanation": "The album 'American Idiot' was released in 2004 and became a cultural phenomenon.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which instrument does Mike Dirnt play in Green Day?",
+          "options": ["Drums", "Bass Guitar", "Lead Guitar", "Keyboard"],
+          "answer": "Bass Guitar",
+          "explanation": "Mike Dirnt is Green Day's bassist and provides backing vocals.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 2,
+      "theme_name": "Grand Line Adventures",
+      "theme_description": "Set sail with questions about the world of One Piece.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is the name of the main protagonist in One Piece?",
+          "answer": "Monkey D. Luffy",
+          "explanation": "Luffy is the rubber-powered captain of the Straw Hat Pirates.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which fruit did Luffy eat to gain his powers?",
+          "options": ["Gomu Gomu no Mi", "Mera Mera no Mi", "Hana Hana no Mi", "Hie Hie no Mi"],
+          "answer": "Gomu Gomu no Mi",
+          "explanation": "The Gomu Gomu no Mi is a Devil Fruit that gives Luffy his rubber abilities.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "Zoro is known for fighting with three swords at once.",
+          "answer": "true",
+          "explanation": "Roronoa Zoro is famous for his unique three-sword style.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "As of 2024, approximately how many episodes of the One Piece anime have aired?",
+          "answer": "1100",
+          "explanation": "One Piece is one of the longest-running anime series, surpassing 1,100 episodes by 2024.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What is the name of the treasure that Luffy seeks?",
+          "answer": "One Piece",
+          "explanation": "The legendary treasure 'One Piece' is said to be at the end of the Grand Line.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which Straw Hat crew member is the ship's navigator?",
+          "options": ["Nami", "Robin", "Sanji", "Usopp"],
+          "answer": "Nami",
+          "explanation": "Nami is the skilled navigator of the Straw Hat Pirates.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 3,
+      "theme_name": "Portal Masters",
+      "theme_description": "Explore the magical universe of Skylanders.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is the name of the main villain in the Skylanders series?",
+          "answer": "Kaos",
+          "explanation": "Kaos is the recurring antagonist in the Skylanders games.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which element is Spyro associated with in Skylanders?",
+          "options": ["Magic", "Fire", "Water", "Earth"],
+          "answer": "Magic",
+          "explanation": "In Skylanders, Spyro is classified as a Magic element character.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "Skylanders figures use NFC technology to interact with the game.",
+          "answer": "true",
+          "explanation": "The figures use NFC chips to transfer character data into the game.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many main Skylanders games were released between 2011 and 2016?",
+          "answer": "6",
+          "explanation": "There were six main Skylanders games released in that period.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What is the name of the device used to bring Skylanders into the game?",
+          "answer": "Portal of Power",
+          "explanation": "The Portal of Power is the platform that reads Skylanders figures.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which of these is NOT a Skylanders element?",
+          "options": ["Tech", "Light", "Wind", "Undead"],
+          "answer": "Wind",
+          "explanation": "Wind is not an element in the Skylanders universe.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 4,
+      "theme_name": "Battle Royale Blitz",
+      "theme_description": "Test your knowledge of Fortnite's world and history.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is the name of Fortnite's in-game currency?",
+          "answer": "V-Bucks",
+          "explanation": "V-Bucks are used to purchase skins, emotes, and more in Fortnite.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which of these is NOT a Fortnite location?",
+          "options": ["Tilted Towers", "Pleasant Park", "Dusty Depot", "Sunny Shores"],
+          "answer": "Sunny Shores",
+          "explanation": "Sunny Shores is not a named location in Fortnite.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "Fortnite was first released in 2017.",
+          "answer": "true",
+          "explanation": "Fortnite's Battle Royale mode launched in 2017.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many players compete in a standard Fortnite Battle Royale match?",
+          "answer": "100",
+          "explanation": "A typical Fortnite match features 100 players fighting to be the last one standing.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What is the name of the storm's safe area that shrinks over time?",
+          "answer": "Circle",
+          "explanation": "Players must stay inside the shrinking circle to survive the storm.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which company developed Fortnite?",
+          "options": ["Epic Games", "Activision", "Ubisoft", "EA"],
+          "answer": "Epic Games",
+          "explanation": "Epic Games is the developer and publisher of Fortnite.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 5,
+      "theme_name": "Internet Inside Jokes",
+      "theme_description": "A round dedicated to meme culture and viral moments.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What animal is featured in the 'Doge' meme?",
+          "answer": "Shiba Inu",
+          "explanation": "The 'Doge' meme features a Shiba Inu dog with multicolored Comic Sans text.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which phrase is associated with the 'Distracted Boyfriend' meme?",
+          "options": ["Looking at another girl", "Hide the Pain", "Mocking SpongeBob", "Woman Yelling at Cat"],
+          "answer": "Looking at another girl",
+          "explanation": "The meme shows a man looking at another woman while his girlfriend looks on disapprovingly.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "'Pepe the Frog' originated as a character in a comic strip.",
+          "answer": "true",
+          "explanation": "Pepe first appeared in Matt Furie's comic 'Boys Club.'",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "In what year did the 'Rickroll' meme first appear on YouTube?",
+          "answer": "2007",
+          "explanation": "The 'Rickroll' meme began in 2007, tricking users into watching Rick Astley's 'Never Gonna Give You Up.'",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What is the name of the meme featuring a white cat sitting at a dinner table?",
+          "answer": "Woman Yelling at Cat",
+          "explanation": "The meme combines a scene from 'The Real Housewives' with a confused-looking cat at a table.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which meme is known for the phrase 'Is this a pigeon?'?",
+          "options": ["Anime Butterfly Guy", "Surprised Pikachu", "Hide the Pain Harold", "Expanding Brain"],
+          "answer": "Anime Butterfly Guy",
+          "explanation": "The 'Is this a pigeon?' meme comes from a scene in the anime 'The Brave Fighter of Sun Fighbird.'",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 6,
+      "theme_name": "Block by Block",
+      "theme_description": "Dig into the world of Minecraft, from crafting to creatures.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is the name of the dimension you reach by building a portal with obsidian and lighting it?",
+          "answer": "Nether",
+          "explanation": "The Nether is a dangerous, lava-filled dimension in Minecraft.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which of these is NOT a Minecraft mob?",
+          "options": ["Creeper", "Enderman", "Blaze", "Golemite"],
+          "answer": "Golemite",
+          "explanation": "Golemite is not a real mob in Minecraft.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "You can craft a diamond pickaxe using only two diamonds.",
+          "answer": "false",
+          "explanation": "A diamond pickaxe requires three diamonds and two sticks.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many blocks high is a standard Minecraft player character?",
+          "answer": "1.8",
+          "explanation": "The player is 1.8 blocks tall in Minecraft.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What is the rarest ore in Minecraft as of 2024?",
+          "answer": "Ancient Debris",
+          "explanation": "Ancient Debris is used to make Netherite and is the rarest naturally occurring ore.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which item is needed to tame a wolf in Minecraft?",
+          "options": ["Bone", "Apple", "Fish", "Carrot"],
+          "answer": "Bone",
+          "explanation": "Bones are used to tame wolves and turn them into loyal dogs.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 7,
+      "theme_name": "Monkey Business",
+      "theme_description": "Pop into the world of Bloons TD6 and its tower defense mayhem.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is the main objective in Bloons TD6?",
+          "answer": "Pop all the bloons",
+          "explanation": "Players must prevent bloons from reaching the end of the path by popping them with towers.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which of these is NOT a monkey tower in Bloons TD6?",
+          "options": ["Dart Monkey", "Ninja Monkey", "Pirate Monkey", "Alchemist"],
+          "answer": "Pirate Monkey",
+          "explanation": "There is no tower called Pirate Monkey, though there is a Monkey Buccaneer.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "Bloons TD6 can be played in co-op mode.",
+          "answer": "true",
+          "explanation": "Co-op mode allows players to team up and defend together.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many upgrade paths does each tower have in Bloons TD6?",
+          "answer": "3",
+          "explanation": "Each tower has three upgrade paths, but only two can be used at once.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What is the name of the most powerful type of bloon, which is black and red and spawns other blimps?",
+          "answer": "BAD",
+          "explanation": "The BAD (Big Airship of Doom) is the toughest bloon in the game.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which currency is used to unlock new heroes in Bloons TD6?",
+          "options": ["Monkey Money", "Banana Bucks", "Bloon Coins", "Tower Tokens"],
+          "answer": "Monkey Money",
+          "explanation": "Monkey Money is earned by playing and used to unlock heroes and other features.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 8,
+      "theme_name": "Challenge Accepted",
+      "theme_description": "A round about Mr. Beast and his wild YouTube stunts.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is Mr. Beast's real first name?",
+          "answer": "Jimmy",
+          "explanation": "Mr. Beast's real name is Jimmy Donaldson.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which of these challenges did Mr. Beast NOT do?",
+          "options": ["Counting to 100,000", "Last to Leave Circle", "Eating 100 Burgers", "Swimming the English Channel"],
+          "answer": "Swimming the English Channel",
+          "explanation": "Mr. Beast has done many wild challenges, but swimming the English Channel is not one of them.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "Mr. Beast has given away over $1 million in a single video.",
+          "answer": "true",
+          "explanation": "He is known for his massive giveaways and philanthropy.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "As of 2024, approximately how many subscribers does Mr. Beast's main YouTube channel have?",
+          "answer": "250000000",
+          "explanation": "Mr. Beast's channel surpassed 250 million subscribers in 2024, making it one of the most-subscribed on YouTube.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What is the name of Mr. Beast's tree-planting campaign?",
+          "answer": "Team Trees",
+          "explanation": "Team Trees aimed to plant 20 million trees worldwide.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which of these is a frequent collaborator in Mr. Beast's videos?",
+          "options": ["Chris", "Logan", "Felix", "Jake"],
+          "answer": "Chris",
+          "explanation": "Chris Tyson is a longtime friend and collaborator in Mr. Beast's videos.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 9,
+      "theme_name": "Kitchen Confidential",
+      "theme_description": "A taste of cooking, food, and culinary basics.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is the term for cooking pasta until it is firm to the bite?",
+          "answer": "Al dente",
+          "explanation": "'Al dente' means the pasta is cooked but still has a slight firmness.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which of these is NOT a type of knife cut?",
+          "options": ["Julienne", "Brunoise", "Chiffonade", "Frittata"],
+          "answer": "Frittata",
+          "explanation": "Frittata is an Italian egg dish, not a knife cut.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "Baking powder and baking soda are the same thing.",
+          "answer": "false",
+          "explanation": "They are different leavening agents with distinct chemical properties.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "At what temperature in Fahrenheit does water boil at sea level?",
+          "answer": "212",
+          "explanation": "Water boils at 212°F (100°C) at sea level.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What is the main ingredient in guacamole?",
+          "answer": "Avocado",
+          "explanation": "Guacamole is a dip made primarily from mashed avocados.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which vitamin is most abundant in citrus fruits?",
+          "options": ["Vitamin C", "Vitamin A", "Vitamin D", "Vitamin K"],
+          "answer": "Vitamin C",
+          "explanation": "Citrus fruits are an excellent source of vitamin C.",
+          "points": 1
+        }
+      ]
+    },
+    {
+      "round_number": 10,
+      "theme_name": "Schoolyard Smarts",
+      "theme_description": "A round of general knowledge every elementary student should know.",
+      "questions": [
+        {
+          "type": "text_answer",
+          "question": "What is the largest planet in our solar system?",
+          "answer": "Jupiter",
+          "explanation": "Jupiter is the biggest planet, known for its Great Red Spot.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which continent is Egypt located on?",
+          "options": ["Africa", "Asia", "Europe", "Australia"],
+          "answer": "Africa",
+          "explanation": "Egypt is a country in northeastern Africa.",
+          "points": 1
+        },
+        {
+          "type": "true_false",
+          "question": "A triangle has four sides.",
+          "answer": "false",
+          "explanation": "A triangle has three sides.",
+          "points": 1
+        },
+        {
+          "type": "closest_number",
+          "question": "How many states are there in the United States?",
+          "answer": "50",
+          "explanation": "The U.S. is made up of 50 states.",
+          "scoring_type": "closest",
+          "points": 1
+        },
+        {
+          "type": "text_answer",
+          "question": "What do plants use to make food from sunlight?",
+          "answer": "Photosynthesis",
+          "explanation": "Photosynthesis is the process by which plants convert sunlight into energy.",
+          "points": 1
+        },
+        {
+          "type": "multiple_choice",
+          "question": "Which of these is a mammal?",
+          "options": ["Dolphin", "Shark", "Octopus", "Penguin"],
+          "answer": "Dolphin",
+          "explanation": "Dolphins are warm-blooded mammals that breathe air.",
+          "points": 1
+        }
+      ]
+    }
+  ]
+}

--- a/community-packs/sports/README.md
+++ b/community-packs/sports/README.md
@@ -1,0 +1,61 @@
+# ⚽ Sports Quiz Packs
+
+Get your game on! Sports packs covering athletics, teams, records, and sporting culture from around the world.
+
+## 📦 Available Packs
+
+### ⛷️ Skiing Around The World
+**File**: [skiing_around_the_world_v1.0.json](skiing_around_the_world_v1.0.json)  
+**Author**: Shannon Williams  
+**Version**: 1.0  
+**Rounds**: 10 | **Questions**: 60 | **Duration**: ~60 minutes
+
+**Description**: Hit the slopes with this comprehensive skiing and winter sports quiz! Perfect for ski enthusiasts and winter sports fans.
+
+**What's Included**:
+- Famous ski resorts worldwide
+- Olympic skiing history and champions
+- Skiing techniques and equipment
+- Alpine vs Nordic skiing traditions
+- Ski industry and mountain culture
+- Winter Olympic sports beyond skiing
+- Skiing legends and record holders
+- Mountain geography and snow science
+
+**Difficulty**: Medium  
+**Best For**: Sports fans, skiing enthusiasts, winter sports lovers  
+**Sample Question**: "Which Alpine skiing technique involves making short, quick turns down steep terrain?"
+
+[📥 Download Pack](skiing_around_the_world_v1.0.json) | [🔍 Preview Questions](#)
+
+---
+
+## 🎯 Pack Suggestions Needed
+
+Missing something? We'd love packs about:
+- **Football (Soccer)** - World Cup, leagues, and legendary players
+- **American Football** - NFL history, teams, and championships
+- **Basketball** - NBA, college ball, and international play
+- **Baseball** - MLB history, records, and legendary moments
+- **Tennis** - Grand Slams, champions, and tennis culture
+- **Olympic Sports** - Summer and Winter Olympic history
+- **European Football** - Premier League, Champions League, and more
+- **Extreme Sports** - Skateboarding, surfing, climbing, and adventure sports
+- **Women's Sports** - Celebrating female athletes and achievements
+- **Sports Statistics** - Records, numbers, and amazing facts
+
+## 🤝 Contributing
+
+Have a sports pack to share? See our [contribution guide](../README.md#contributing-your-own-pack) to get started!
+
+**Sports Pack Tips**:
+- Balance popular and niche sports
+- Include both historical and current information
+- Mix player facts with rules and culture
+- Consider international perspectives, not just one country
+- Verify statistics and records carefully (they change!)
+- Include explanations that teach sports knowledge
+
+---
+
+**🔙 [Back to Community Packs](../README.md)**

--- a/docs/AI-Question-Creation-Guide.md
+++ b/docs/AI-Question-Creation-Guide.md
@@ -204,6 +204,8 @@ Quiz packs must be saved as properly formatted JSON files with this exact struct
 - Use kebab-case: `pack-name-here.json`
 - No spaces or special characters
 - Include version if multiple versions exist: `pack-name-v2.json`
+- Place in the `community-packs/` directory for community submissions
+- Built-in packs can also be placed in `quizpacks/` directory
 
 ## 🎨 Creative Theme Ideas
 
@@ -241,6 +243,11 @@ Explanation: "The Golden Gate Bridge is painted in International Orange to enhan
 **Strengths**: Theme doesn't reveal bridge, question tests knowledge, educational explanation
 
 ## 📚 Additional Resources
+
+### Pack Creation Tools
+- Use the built-in Pack Editor in Quizzly Bear for creating and testing packs
+- JSON validation tools to ensure proper formatting
+- The app's import/export functionality for sharing packs
 
 ### Recommended Verification Sources
 - Encyclopedia Britannica


### PR DESCRIPTION
Adds the 2019 – The Year That Was quiz pack to the community-packs directory. This pack features 10 rounds and 60 questions focused on the major events, pop culture, sports, science, and surprises of 2019, with all questions at medium or hard difficulty.